### PR TITLE
Merge Feature/deploy cloud into develop

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*.ipynb
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt .
 RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application code
-COPY . .
+COPY challenge /app/challenge
 
 # Expose the port the app runs on
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,20 @@
-# syntax=docker/dockerfile:1.2
-FROM python:latest
-# put you docker configuration here
+# Define the base image
+FROM python:3.10-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy only requirements.txt first to leverage Docker cache
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Use CMD to run the application
+CMD ["uvicorn", "challenge.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:		## Install dependencies
 	pip install -r requirements-test.txt
 	pip install -r requirements.txt
 
-STRESS_URL = http://127.0.0.1:8000 
+STRESS_URL = https://mle-challenge-756665630445.southamerica-west1.run.app
 .PHONY: stress-test
 stress-test:
 	# change stress url to your deployed app 

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -193,5 +193,33 @@ To deploy the model in an `API` using `FastAPI` and pass all the unit tests, it 
 
 ## Part III
 
+[Back to the start](#mle-challenge)
+
+With the previous scripts fully functional, we are now ready to deploy our API to the cloud. For this, we use **Cloud Run**, a Google Cloud Platform (GCP) service that simplifies the deployment of containerized applications.
+
+You can access the deployed application here:  
+[Deployed Application](https://mle-challenge-756665630445.southamerica-west1.run.app)
+
+To enable deployment, we applied the following key changes to the repository:
+
+- **Dockerfile:**  
+  - Updated the Python base image to `python:3.10-slim` to reduce the image size.  
+  - Configured the Dockerfile to copy application scripts, install dependencies, and launch the API on port 8000.
+
+- **requirements.txt:**  
+  - Upgraded `scikit-learn` from version `1.3.0` to `~1.5.0` to prevent deployment errors.
+
+- **requirements-test.txt:**  
+  - Added libraries to support the stress testing phase and avoid related errors:  
+    - `Jinja2==3.0.3`  
+    - `itsdangerous==2.0.1`  
+    - `Werkzeug==2.0.3`
+
+- **Makefile:**  
+  - Updated the `STRESS_URL` variable to point to the URL of the deployed API.
+
+- **.dockerignore:**  
+  - Added a `.dockerignore` file to exclude unnecessary files from the Docker build context, helping to reduce the image size.
+
 ## Part IV
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,6 @@ coverage~=5.5
 pytest~=6.2.5
 pytest-cov~=2.12.1
 mockito~=1.2.2
+Jinja2==3.0.3
+itsdangerous==2.0.1
+Werkzeug==2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pydantic~=1.10.2
 uvicorn~=0.15.0
 numpy~=1.25
 pandas~=1.3.5
-scikit-learn~=1.3.0
+scikit-learn~=1.5.0
 xgboost==3.0.3
 anyio==3.4.0


### PR DESCRIPTION
Completed Part III of the challenge. Here's a summary of the key changes made:

- **Dockerfile:**  
  - Updated the Python base image to `python:3.10-slim` to reduce the image size.  
  - Configured the Dockerfile to copy application scripts, install dependencies, and launch the API on port 8000.

- **requirements.txt:**  
  - Upgraded `scikit-learn` from version `1.3.0` to `~1.5.0` to prevent deployment errors.

- **requirements-test.txt:**  
  - Added libraries to support the stress testing phase and avoid related errors:  
    - `Jinja2==3.0.3`  
    - `itsdangerous==2.0.1`  
    - `Werkzeug==2.0.3`

- **Makefile:**  
  - Updated the `STRESS_URL` variable to point to the URL of the deployed API.

- **.dockerignore:**  
  - Added a `.dockerignore` file to exclude unnecessary files from the Docker build context, helping to reduce the image size.